### PR TITLE
Version parsing and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# MegaMol-Shader-Factory v0.1
+# MegaMol-Shader-Factory
 
 Contains utility methods to handle includes in OpenGL shaders.
 
 ## Using
-  - glslang - License: multiple licenses
-  - parts of shaderc - License: Apache 2.0
-  - glad
+  - [glslang](https://github.com/KhronosGroup/glslang) - License: multiple licenses
+  - parts of [shaderc](https://github.com/google/shaderc) - License: Apache 2.0

--- a/cmake/libs.cmake
+++ b/cmake/libs.cmake
@@ -11,7 +11,7 @@ mark_as_advanced(FORCE
 # glslang
 FetchContent_Declare(glslang
   GIT_REPOSITORY https://github.com/KhronosGroup/glslang.git
-  GIT_TAG 11.6.0)
+  GIT_TAG 11.8.0)
 FetchContent_GetProperties(glslang)
 if (NOT glslang_POPULATED)
   FetchContent_Populate(glslang)

--- a/src/ShaderFactory.cpp
+++ b/src/ShaderFactory.cpp
@@ -45,32 +45,27 @@ std::tuple<bool, int, EProfile> find_and_parse_version_string(std::string const&
 }
 
 EShLanguage get_shader_type(std::filesystem::path const& file_path) {
-    auto const shader_ext = msf::getShaderExtensionString(file_path);
-    if (shader_ext == ".vert") {
+    switch (msf::getShaderType(file_path)) {
+    case msf::ShaderType::Vertex:
         return EShLanguage::EShLangVertex;
-    }
-    if (shader_ext == ".tesc") {
+    case msf::ShaderType::TessControl:
         return EShLanguage::EShLangTessControl;
-    }
-    if (shader_ext == ".tese") {
+    case msf::ShaderType::TessEvaluation:
         return EShLanguage::EShLangTessEvaluation;
-    }
-    if (shader_ext == ".geom") {
+    case msf::ShaderType::Geometry:
         return EShLanguage::EShLangGeometry;
-    }
-    if (shader_ext == ".frag") {
+    case msf::ShaderType::Fragment:
         return EShLanguage::EShLangFragment;
-    }
-    if (shader_ext == ".comp") {
+    case msf::ShaderType::Compute:
         return EShLanguage::EShLangCompute;
-    }
-    if (shader_ext == ".mesh") {
+    case msf::ShaderType::Mesh:
         return EShLanguage::EShLangMeshNV;
-    }
-    if (shader_ext == ".task") {
+    case msf::ShaderType::Task:
         return EShLanguage::EShLangTaskNV;
+    case msf::ShaderType::None:
+    default:
+        return EShLanguage::EShLangVertex; // Default to vertex.
     }
-    return EShLanguage::EShLangVertex;
 }
 } // namespace
 

--- a/src/ShaderFactory.cpp
+++ b/src/ShaderFactory.cpp
@@ -5,6 +5,7 @@
 #include "msf/ShaderFactory.h"
 
 #include <algorithm>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -17,32 +18,30 @@
 #include "msf/ShaderFactoryUtils.h"
 
 namespace {
-/*
- * Adapted from : https://github.com/google/shaderc/blob/main/libshaderc_util/src/compiler.cc
- * License : Apache 2.0
- */
+
 std::tuple<bool, int, EProfile> find_and_parse_version_string(std::string const& shader_source) {
-    auto version_pos = shader_source.find("#version");
-    if (version_pos == std::string::npos) {
-        return std::make_tuple(false, 0, ENoProfile);
-    }
-    auto version_string = shader_source.substr(version_pos + std::strlen("#version"));
-    version_string = version_string.substr(0, version_string.find_first_of('\n'));
-    version_string.erase(std::remove(version_string.begin(), version_string.end(), ' '), version_string.end());
-    int version = 0;
-    std::string profile_name;
-    std::istringstream(version_string) >> version >> profile_name;
+    // Find first '#version' at beginning of a line (ignoring white spaces)
+    std::regex regex("(^|\n)\\s*#version\\s*(.*)");
+    std::smatch match;
+    if (std::regex_search(shader_source, match, regex)) {
+        int version = 0;
+        std::string profile_name;
+        std::istringstream(match[2].str()) >> version >> profile_name;
 
-    EProfile profile = ENoProfile;
+        EProfile profile = ENoProfile;
 
-    if (profile_name == glslang::ProfileName(ECoreProfile)) {
-        profile = ECoreProfile;
-    }
-    if (profile_name == glslang::ProfileName(ECompatibilityProfile)) {
-        profile = ECompatibilityProfile;
+        if (profile_name == glslang::ProfileName(ECoreProfile)) {
+            profile = ECoreProfile;
+        } else if (profile_name == glslang::ProfileName(ECompatibilityProfile)) {
+            profile = ECompatibilityProfile;
+        } else if (profile_name == glslang::ProfileName(EEsProfile)) {
+            profile = EEsProfile;
+        }
+
+        return std::make_tuple(true, version, profile);
     }
 
-    return std::make_tuple(true, version, profile);
+    return std::make_tuple(false, 0, ENoProfile);
 }
 
 EShLanguage get_shader_type(std::filesystem::path const& file_path) {
@@ -146,7 +145,7 @@ std::string msf::ShaderFactory::preprocess(
     EProfile profile = ENoProfile;
     std::tie(succes_version_string, version, profile) = find_and_parse_version_string(shader_source);
     if (!succes_version_string) {
-        return std::string();
+        throw std::runtime_error("Error preprocessing shader: missing #version");
     }
 
     Includer includer(options.getIncludePaths());


### PR DESCRIPTION
- throw an exception if `#version` is missing, instead of silently returning an empty shader source string
- make version parsing more stable by using regex instead of find
- avoid redundant file extension definitions
- update glslang (removes a CMake warning from upstream CMake code)
- remove version from readme title and add links to used projects