### PR TITLE
No extension errors

### DIFF
--- a/cmake/libs.cmake
+++ b/cmake/libs.cmake
@@ -11,7 +11,7 @@ mark_as_advanced(FORCE
 # glslang
 FetchContent_Declare(glslang
   GIT_REPOSITORY https://github.com/KhronosGroup/glslang.git
-  GIT_TAG 11.8.0)
+  GIT_TAG 11.9.0)
 FetchContent_GetProperties(glslang)
 if (NOT glslang_POPULATED)
   FetchContent_Populate(glslang)

--- a/src/ShaderFactory.cpp
+++ b/src/ShaderFactory.cpp
@@ -146,7 +146,7 @@ std::string msf::ShaderFactory::preprocess(
     Includer includer(options.getIncludePaths());
     std::string output;
     auto const success = shader.preprocess(
-        &glslang::DefaultTBuiltInResource, version, profile, true, false, EShMsgDefault, &output, includer);
+        &glslang::DefaultTBuiltInResource, version, profile, true, false, EShMsgOnlyPreprocessor, &output, includer);
 
     if (!success) {
         throw std::runtime_error(std::string("Error preprocessing shader:\n") + shader.getInfoLog());


### PR DESCRIPTION
- Use EShMsgOnlyPreprocessor to not trigger errors from missing extensions
- Update glslang to 11.9.0