### PR TITLE
Update glslang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.26 FATAL_ERROR)
 
 # Project
 project(msf

--- a/cmake/fetch_glslang.cmake
+++ b/cmake/fetch_glslang.cmake
@@ -10,8 +10,8 @@ mark_as_advanced(FORCE
 
 # glslang
 FetchContent_Declare(glslang
-  GIT_REPOSITORY https://github.com/KhronosGroup/glslang.git
-  GIT_TAG 12.1.0)
+  URL "https://github.com/KhronosGroup/glslang/archive/12.1.0.tar.gz"
+  URL_HASH SHA256=1515e840881d1128fb6d831308433f731808f818f2103881162f3ffd47b15cd5)
 FetchContent_GetProperties(glslang)
 if (NOT glslang_POPULATED)
   message(STATUS "Fetch glslang ...")

--- a/cmake/fetch_glslang.cmake
+++ b/cmake/fetch_glslang.cmake
@@ -11,7 +11,7 @@ mark_as_advanced(FORCE
 # glslang
 FetchContent_Declare(glslang
   GIT_REPOSITORY https://github.com/KhronosGroup/glslang.git
-  GIT_TAG 12.0.0)
+  GIT_TAG 12.1.0)
 FetchContent_GetProperties(glslang)
 if (NOT glslang_POPULATED)
   message(STATUS "Fetch glslang ...")
@@ -20,7 +20,7 @@ if (NOT glslang_POPULATED)
   option(BUILD_SHARED_LIBS "" OFF)
   option(ENABLE_CTEST "" OFF)
   option(ENABLE_EXCEPTIONS "" ON)
-  option(ENABLE_GLSLANG_BINARIES "" OFF) # see comment about glslang-default-resource-limits below
+  option(ENABLE_GLSLANG_BINARIES "" OFF)
   option(ENABLE_GLSLANG_JS "" OFF)
   option(ENABLE_HLSL "" OFF)
   option(ENABLE_OPT "" OFF)
@@ -32,17 +32,3 @@ if (NOT glslang_POPULATED)
     FETCHCONTENT_SOURCE_DIR_GLSLANG
     FETCHCONTENT_UPDATES_DISCONNECTED_GLSLANG)
 endif ()
-
-# We want to use glslang-default-resource-limits which is included with ENABLE_GLSLANG_BINARIES. Unfortunately, other
-# targets also enabled with ENABLE_GLSLANG_BINARIES require Python which we do not want as hard dependency of the
-# shader factory. Therefore, we manually create the glslang-default-resource-limits target here without enabling
-# ENABLE_GLSLANG_BINARIES.
-
-add_library(glslang-default-resource-limits STATIC EXCLUDE_FROM_ALL
-  ${glslang_SOURCE_DIR}/StandAlone/ResourceLimits.cpp
-  ${glslang_SOURCE_DIR}/StandAlone/resource_limits_c.cpp)
-set_property(TARGET glslang-default-resource-limits PROPERTY FOLDER glslang)
-set_property(TARGET glslang-default-resource-limits PROPERTY POSITION_INDEPENDENT_CODE ON)
-
-target_include_directories(glslang-default-resource-limits
-  PUBLIC $<BUILD_INTERFACE:${glslang_SOURCE_DIR}>)


### PR DESCRIPTION
- Update glslang to 12.1.0. Resouce limits are now included directly with the library, so we can remove the workaround.
- Use tar.gz download for glslang: It is faster to download, it does not require git installed and allows to add a hash for verification.